### PR TITLE
Fix module specifiers.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,8 +5,8 @@
 </template>
 
 <script>
-  import page1 from 'Page1';
-  import page2 from 'Page2';
+  import page1 from './Page1';
+  import page2 from './Page2';
 
   export default {
     data() {

--- a/src/Page1.vue
+++ b/src/Page1.vue
@@ -9,8 +9,8 @@
 </template>
 
 <script>
-  import customToolbar from 'customToolbar';
-  import page2 from 'Page2';
+  import customToolbar from './CustomToolbar';
+  import page2 from './Page2';
   export default {
      methods: {
        pop(){

--- a/src/Page2.vue
+++ b/src/Page2.vue
@@ -6,8 +6,8 @@
 </template>
 
 <script>
-  import customToolbar from 'customToolbar';
-  import app from 'App';
+  import customToolbar from './CustomToolbar';
+  import app from './App';
 
   export default {
     methods: {

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import 'onsenui';
 require('onsenui/css-components-src/src/onsen-css-components.css');
 require('onsenui/css/onsenui.css');
 
-import App from './App.vue';
+import App from './App';
 
 Vue.use(VueOnsen);
 


### PR DESCRIPTION
@adamkozuch @andipavllo 
The current `navigation` template has the following problems:
 - `import page1 from 'Page1';` should be `import page1 from './Page1';`
    - `'Page1'` impiles `Page1 is a module package`.
    - `'./Page1'` impiles `Page1 is a module file`.
    - Therefore we should use relative paths for our files.
 - `import customToolbar from 'customToolbar';` should be `import customToolbar from './CustomToolbar';`
    - The original file name is `CustomToolbar.vue`, not `customToolbar.vue`.
    - This causes a problem on OS which has a case-sensitive file system such as Linux.
    In fact, this template does not work on Linux: https://circleci.com/gh/monaca-templates/onsenui-v2-vue-navigation/3
 - `import App from './App.vue';` should be `import App from './App';`
    - We do not have to include extensions since we have the setting about default extensions (in `webpack.prod.config.js` and `webpack.dev.config.js`).

Could you merge this and retag `2.2.7`?